### PR TITLE
Fix #21

### DIFF
--- a/src/discord_commands.rs
+++ b/src/discord_commands.rs
@@ -477,7 +477,8 @@ async fn upload_character(
         .open(&char_path)
         .await?;
     //Write
-    let mut writer = io::BufWriter::new(file);
+    let mut writer =
+        io::BufWriter::with_capacity(config.discord.max_attachement_size as usize, file);
     writer.write(&data).await?;
     writer.flush().await?;
     match Character::from_file(&char_path).await {


### PR DESCRIPTION
Fix  #21 by increasing Buffer size to config property set in discord.max_attachement_size.

This ensures every upload fulfilling the attachment requirement will be able to  be saved.