### PR TITLE
Implement `rename` command for discord

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -43,6 +43,14 @@ pub fn get_discord_app() -> App<'static> {
         .subcommand(cmd_dodge())
         .subcommand(cmd_parry())
         .subcommand(cmd_roll())
+        .subcommand(App::new("rename").about("Rename all players to their respective character name")
+            .arg(
+                Arg::new("reset")
+                .about("Reset player nicknames to their original names")
+                .short('r')
+                .long("reset")
+                .takes_value(false)
+            ))
         .subcommand(App::new("ini").about("Performs an initiative roll for the current character")
             .arg(
                 Arg::new("all")


### PR DESCRIPTION
This command will rename participating users to be prefixed with their character name.
The option `reset` will revert all changes to usernames (including `ini` as they are prefixed before the character name).

The characters name will be separated by the original name with `Ξ`.
This character will be used to later return to the original name, thus no `Ξ` shall be allowed in user names. 

We may have to watch out for max length of discord nicknames (32 iirc)